### PR TITLE
Swapping out oraclejdk8 with openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
     - 2.11.8
 jdk:
-    - oraclejdk8
+    - openjdk8
 notifications:
   email:
     on_success: never # default: change


### PR DESCRIPTION
**Issue**: Travis CI - master branch build failure #11 

To address the Travis CI build error:

> Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .